### PR TITLE
Added feature to ignore Build version check

### DIFF
--- a/src/main/java/fr/Alphart/BAT/BAT.java
+++ b/src/main/java/fr/Alphart/BAT/BAT.java
@@ -63,8 +63,9 @@ public class BAT extends Plugin {
 		  getLogger().warning("BungeeCord version check disabled because a fork has been detected."
               + " Make sur your fork is based on a BungeeCord build > #" + requiredBCBuild);
 		}
-		else if(getBCBuild() < requiredBCBuild){
+		else if(getBCBuild() < requiredBCBuild && !BAT.getInstance().getConfiguration().isIgnoreBuildCheck()){
 		  getLogger().severe("Your BungeeCord build (#" + getBCBuild() + ") is not supported. Please use at least BungeeCord #" + requiredBCBuild);
+		  getLogger().severe("If you are using a custom build of BungeeCord, set ignoreBuildCheck to false in BAT's config.yml");
           getLogger().severe("BAT is going to shutdown ...");
           return;
 		}

--- a/src/main/java/fr/Alphart/BAT/Configuration.java
+++ b/src/main/java/fr/Alphart/BAT/Configuration.java
@@ -28,6 +28,8 @@ public class Configuration extends Config{
 	private String language = "en";
 	private String prefix = "&6[&4BAT&6]&e ";
 	
+        @Comment("Ignore BungeeCord build version check on enable. (Useful when using a forked version but using BungeeCord as the same name)")
+        private boolean ignoreBuildCheck= false;
     @Comment("Force players to give reason when /ban /unban /kick /mute /unmute etc.")
 	private boolean mustGiveReason= false;
 	@Comment("Enable /bat confirm, to confirm command such as action on unknown player.")


### PR DESCRIPTION
This commit is to support
https://github.com/HexagonMC/BungeeCord/issues/9 to allow forked version of Bungeecord that have not yet (or wont be) changing their name